### PR TITLE
Small address API improvement.

### DIFF
--- a/examples/symbol/aggregate.ts
+++ b/examples/symbol/aggregate.ts
@@ -1,3 +1,4 @@
+import { Converter, Key, SymbolDeadline, SymbolKeyPair, SymbolNetwork } from '@core';
 import { ChronoUnit } from '@js-joda/core';
 import {
     AmountDto,
@@ -9,7 +10,6 @@ import {
     UnresolvedMosaicBuilder,
     UnresolvedMosaicIdDto,
 } from 'catbuffer-typescript';
-import { Converter, Key, SymbolAddress, SymbolDeadline, SymbolKeyPair, SymbolNetwork } from '../../src/core';
 
 const mosaicId = BigInt('0x091F837E059AE13C'); // Testnet mosaic id
 
@@ -23,7 +23,7 @@ const bobAddressAlias = 'bob.address'; // Bob's address alias namespace name
 const network = new SymbolNetwork('testnet', 0x98, '3B5E1FA6445653C971A50687E75E6D09FB30481055E3990C84B25E9222DC1155'); // Specify network
 const factory = network.createTransactionFactory();
 
-const aliceAddress = new SymbolAddress(network.createAddressFromPublicKey(aliceKeyPair.publicKey));
+const aliceAddress = network.createAddressFromPublicKey(aliceKeyPair.publicKey);
 const bobAddress = factory.fullNameToNamespaceId(bobAddressAlias); // Bob's unresolved address
 
 const aliceTransaction = new TransferTransactionBodyBuilder({

--- a/examples/symbol/multisig.ts
+++ b/examples/symbol/multisig.ts
@@ -1,6 +1,6 @@
 /* eslint-disable tsdoc/syntax */
+import { Key, SymbolDeadline, SymbolKeyPair, SymbolNetwork } from '@core';
 import { MultisigAccountModificationTransactionBodyBuilder, UnresolvedAddressDto } from 'catbuffer-typescript';
-import { Key, SymbolAddress, SymbolDeadline, SymbolKeyPair, SymbolNetwork } from '../../src/core';
 
 const multisigKeyPair = new SymbolKeyPair(Key.createFromHex('1C16D0C8804546EFB4B11584AFACB294DFABF0D41E8E345F1F74BB6CAD162066'));
 const cosignatoryKeyPairs = [
@@ -18,7 +18,7 @@ const network = SymbolNetwork.findByIdentifier(SymbolNetwork.list(), 0x98);
 const factory = network!.createTransactionFactory();
 
 const addressAdditions = cosignatoryKeyPairs.map(
-    (keyPair) => new UnresolvedAddressDto(new SymbolAddress(network!.createAddressFromPublicKey(keyPair.publicKey)).getAddressBytes()),
+    (keyPair) => new UnresolvedAddressDto(network!.createAddressFromPublicKey(keyPair.publicKey).getAddressBytes()),
 );
 
 const bodyBuilder = new MultisigAccountModificationTransactionBodyBuilder({

--- a/examples/symbol/transfer.ts
+++ b/examples/symbol/transfer.ts
@@ -1,3 +1,4 @@
+import { Converter, Key, SymbolAddress, SymbolDeadline, SymbolKeyPair, SymbolNetwork } from '@core';
 import {
     AmountDto,
     TransferTransactionBodyBuilder,
@@ -5,7 +6,6 @@ import {
     UnresolvedMosaicBuilder,
     UnresolvedMosaicIdDto,
 } from 'catbuffer-typescript';
-import { Converter, Key, SymbolAddress, SymbolDeadline, SymbolKeyPair, SymbolNetwork } from '../../src/core';
 
 const testnetMosaicId = '091F837E059AE13C';
 const privateKey = '1C16D0C8804546EFB4B11584AFACB294DFABF0D41E8E345F1F74BB6CAD162066';

--- a/src/core/Network.ts
+++ b/src/core/Network.ts
@@ -15,7 +15,7 @@
  */
 
 import ripemd160 = require('ripemd160');
-import { Key, RawAddress } from '@core';
+import { Address, Key, RawAddress } from '@core';
 import { Hash } from 'js-sha3';
 
 export abstract class Network {
@@ -33,7 +33,7 @@ export abstract class Network {
      * @param publicKey - Public key
      * @returns Raw address and its checksum bytes
      */
-    public createAddressFromPublicKey(publicKey: Key): RawAddress {
+    public createAddressFromPublicKey(publicKey: Key): Address {
         const publicKeyBytes = publicKey.toBytes();
         // step 1: sha3 hash of the public key
         const publicKeyHash = this.addressHasher().arrayBuffer(publicKeyBytes);
@@ -50,8 +50,15 @@ export abstract class Network {
         const hash = this.addressHasher().arrayBuffer(addressWithoutChecksum);
         const checksum = new Uint8Array(hash).subarray(0, 4);
 
-        return { addressWithoutChecksum, checksum };
+        return this.createAddress({ addressWithoutChecksum, checksum });
     }
+
+    /**
+     * Abstract method that creates the right address implementation for the given network.
+     * @param rawAddress - the raw address
+     * @returns the address instance for the current network.
+     */
+    protected abstract createAddress(rawAddress: RawAddress): Address;
 
     /**
      * Abstract method to gets the primary hasher to use in the public key to address conversion.

--- a/src/core/nis1/Nis1Network.ts
+++ b/src/core/nis1/Nis1Network.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
+import { Address, Network, NIS1NetworkList, RawAddress } from '@core';
 import { Hash, keccak256 } from 'js-sha3';
-import { NIS1NetworkList } from '../constants';
-import { Network } from '../Network';
 
 export class Nis1Network extends Network {
     /**
@@ -45,5 +44,14 @@ export class Nis1Network extends Network {
      */
     public static list(): ReadonlyArray<Nis1Network> {
         return NIS1NetworkList.map((n) => new Nis1Network(n.name, n.identifier));
+    }
+
+    /**
+     * It creates the address for the nis1 network.
+     * @param rawAddress - the raw address
+     * @returns the Nis1 address instance.
+     */
+    protected createAddress(rawAddress: RawAddress): Address {
+        throw new Error('Nis1Address not implemented!!!');
     }
 }

--- a/src/core/symbol/SymbolNetwork.ts
+++ b/src/core/symbol/SymbolNetwork.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Network, SymbolNetworkList, SymbolTransactionFactory } from '@core';
+import { Network, RawAddress, SymbolAddress, SymbolNetworkList, SymbolTransactionFactory } from '@core';
 import { Hash, sha3_256 } from 'js-sha3';
 
 export class SymbolNetwork extends Network {
@@ -52,5 +52,13 @@ export class SymbolNetwork extends Network {
      */
     public static list(): ReadonlyArray<SymbolNetwork> {
         return SymbolNetworkList.map((n) => new SymbolNetwork(n.name, n.identifier, n.generationHash));
+    }
+    /**
+     * It creates the address for the symbol network.
+     * @param rawAddress - the raw address
+     * @returns the symbol address instance
+     */
+    protected createAddress(rawAddress: RawAddress): SymbolAddress {
+        return new SymbolAddress(rawAddress);
     }
 }

--- a/test/BasicVectorTest.template.ts
+++ b/test/BasicVectorTest.template.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Key, SymbolAddress, SymbolIdGenerator, SymbolNetwork } from '@core';
+import { Key, SymbolIdGenerator, SymbolNetwork } from '@core';
 import { Converter } from '@utils';
 import { toBufferLE } from 'bigint-buffer';
 import { expect } from 'chai';
@@ -76,9 +76,8 @@ export const AddressMosaicIdTester = (testSignVectorFile: string, testMosaicId =
                     const addressKeyName = `address_${networkName}`.replace('_t', 'T');
                     const mosaicKeyName = `mosaicId_${networkName}`.replace('_t', 'T');
 
-                    // Act + Assert:
-                    const rawAddress = network.createAddressFromPublicKey(Key.createFromHex(item.publicKey));
-                    const address = new SymbolAddress(rawAddress);
+                    // Act + address:
+                    const address = network.createAddressFromPublicKey(Key.createFromHex(item.publicKey));
                     expect(item[addressKeyName]).to.be.equal(address.encoded);
                     if (testMosaicId) {
                         const mosaicId = SymbolIdGenerator.generateMosaicId(address, toBufferLE(BigInt(item['mosaicNonce']), 4));

--- a/test/core/symbol/Address.spec.ts
+++ b/test/core/symbol/Address.spec.ts
@@ -29,7 +29,7 @@ describe('Symbol Address', () => {
     it('Can generate address bytes', () => {
         //Arrange
         const network = new SymbolNetwork('public', 0x68, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
-        const address = new SymbolAddress(network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey)));
+        const address = network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey));
         expect(address.getAddressBytes()).not.to.be.undefined;
         expect(address.getAddressBytes().length).to.be.equal(24);
     });
@@ -60,7 +60,7 @@ describe('Symbol Address', () => {
     it('Can return encoded address', () => {
         //Arrange
         const network = new SymbolNetwork('public', 0x68, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
-        const address = new SymbolAddress(network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey)));
+        const address = network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey));
         expect(address.encoded).not.to.be.undefined;
         expect(address.encoded).to.be.equal(testKeyAddressPair.address_Public);
     });
@@ -68,7 +68,7 @@ describe('Symbol Address', () => {
     it('Can return decoded address', () => {
         //Arrange
         const network = new SymbolNetwork('public', 0x68, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
-        const address = new SymbolAddress(network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey)));
+        const address = network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey));
         expect(address.decode).not.to.be.undefined;
         expect(address.decode).to.be.equal('6826D27E1D0A26CA4E316F901E23E55C8711DB20DF250DEF');
     });
@@ -76,7 +76,7 @@ describe('Symbol Address', () => {
     it('Can return pretty address presentation', () => {
         //Arrange
         const network = new SymbolNetwork('public', 0x68, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
-        const address = new SymbolAddress(network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey)));
+        const address = network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey));
         expect(address.pretty()).not.to.be.undefined;
         expect(address.pretty()).to.be.equal('NATNE7-Q5BITM-UTRRN6-IB4I7F-LSDRDW-ZA34SQ-33Y');
     });
@@ -84,7 +84,7 @@ describe('Symbol Address', () => {
     it('Can compare with other address', () => {
         //Arrange
         const network = new SymbolNetwork('public', 0x68, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
-        const address = new SymbolAddress(network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey)));
+        const address = network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey));
         expect(address.equals(testKeyAddressPair.address_Public)).to.be.true;
         expect(address.equals(testKeyAddressPair.address_Private)).to.be.false;
     });
@@ -92,7 +92,7 @@ describe('Symbol Address', () => {
     it('Can return encoded address by calling toString', () => {
         //Arrange
         const network = new SymbolNetwork('public', 0x68, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
-        const address = new SymbolAddress(network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey)));
+        const address = network.createAddressFromPublicKey(Key.createFromHex(testKeyAddressPair.publicKey));
         expect(address.toString()).not.to.be.undefined;
         expect(address.toString()).to.be.equal(address.encoded);
     });

--- a/test/core/symbol/SymbolTransaction.spec.ts
+++ b/test/core/symbol/SymbolTransaction.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Converter, Key, SymbolAddress, SymbolDeadline, SymbolKeyPair, SymbolNetwork, SymbolTransactionUtils } from '@core';
+import { Converter, Key, SymbolDeadline, SymbolKeyPair, SymbolNetwork, SymbolTransactionUtils } from '@core';
 import {
     AmountDto,
     KeyDto,
@@ -45,8 +45,7 @@ describe('Symbol Transfer Transaction', () => {
     const cosigner2 = new SymbolKeyPair(Key.createFromHex(cosigner2PrivateKeyHex));
 
     const recipientAddressPublicKeyHex = 'BBB80097FB6A1F287ED2736A597B8EA7F08D20F1ECDB9935DE6694ECF1C58900';
-    const rawAddress = network.createAddressFromPublicKey(Key.createFromHex(recipientAddressPublicKeyHex));
-    const recipientSymbolAddress = new SymbolAddress(rawAddress);
+    const recipientSymbolAddress = network.createAddressFromPublicKey(Key.createFromHex(recipientAddressPublicKeyHex));
     const deadline = SymbolDeadline.createFromAdjustedValue(100);
     const namespaceId = BigInt(8589934593);
 

--- a/test/core/symbol/SymbolTransactionAggregate.spec.ts
+++ b/test/core/symbol/SymbolTransactionAggregate.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Converter, Key, SymbolAddress, SymbolDeadline, SymbolKeyPair, SymbolNetwork, SymbolUnresolvedAddress } from '@core';
+import { Converter, Key, SymbolDeadline, SymbolKeyPair, SymbolNetwork, SymbolUnresolvedAddress } from '@core';
 import {
     AmountDto,
     BlockDurationDto,
@@ -42,7 +42,7 @@ describe('Symbol Aggregate Transaction', () => {
 
     const bobPrivateKey = 'AAA80097FB6A1F287ED2736A597B8EA7F08D20F1ECDB9935DE6694ECF1C58900';
     const bob = new SymbolKeyPair(Key.createFromHex(bobPrivateKey));
-    const bobAddress: SymbolUnresolvedAddress = new SymbolAddress(network.createAddressFromPublicKey(bob.publicKey));
+    const bobAddress: SymbolUnresolvedAddress = network.createAddressFromPublicKey(bob.publicKey);
 
     const alicePrivateKey = 'BBB80097FB6A1F287ED2736A597B8EA7F08D20F1ECDB9935DE6694ECF1C58900';
     const alice = new SymbolKeyPair(Key.createFromHex(alicePrivateKey));

--- a/test/core/symbol/SymbolTransactionUtils.spec.ts
+++ b/test/core/symbol/SymbolTransactionUtils.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Key, SymbolAddress, SymbolDeadline, SymbolNetwork, SymbolTransactionUtils } from '@core';
+import { Key, SymbolDeadline, SymbolNetwork, SymbolTransactionUtils } from '@core';
 import {
     AmountDto,
     EmbeddedTransactionBuilder,
@@ -40,8 +40,8 @@ describe('SymbolTransactionUtils', () => {
     }
 
     const recipientAddressPublicKeyHex = 'BBB80097FB6A1F287ED2736A597B8EA7F08D20F1ECDB9935DE6694ECF1C58900';
-    const rawAddress = network.createAddressFromPublicKey(Key.createFromHex(recipientAddressPublicKeyHex));
-    const recipientSymbolAddress = new SymbolAddress(rawAddress);
+    const recipientSymbolAddress = network.createAddressFromPublicKey(Key.createFromHex(recipientAddressPublicKeyHex));
+
     const deadline = SymbolDeadline.createFromAdjustedValue(100);
     const mosaicIdNumber = BigInt(8589934593);
 


### PR DESCRIPTION
Small address API improvement. RawAddress should be private/internal not part of what a dev uses, network knows how to create the right Address instance.

One way of abstracting out how to create a generic address without specifying Symbol or Nis1 for a given network.

Api:
```
const rawAddress = network.createAddressFromPublicKey(Key.createFromHex(item.publicKey));
const address = new SymbolAddress(rawAddress);
```
vs
```
 const address = network.createAddressFromPublicKey(Key.createFromHex(item.publicKey));
 ```
 