### PR TITLE
fix: rolledback getPublicKey() public method. 

### DIFF
--- a/src/core/KeyPair.ts
+++ b/src/core/KeyPair.ts
@@ -18,23 +18,17 @@ import { Key } from '@core';
 import { Converter } from '@utils';
 
 export abstract class KeyPair {
-    public readonly publicKey: Key;
-
     /**
      * Constructor
      *
-     * @param privateKey - Private Key
+     * @param privateKey - The private key.
+     * @param publicKey - The derived public key from the provided private key.
      */
-    constructor(public readonly privateKey: Key) {
+    protected constructor(public readonly privateKey: Key, public readonly publicKey: Key) {
         // sanity
         Converter.validateHexString(privateKey.toString(), 64, 'Invalid PrivateKey');
-        this.publicKey = this.getPublicKey();
+        Converter.validateHexString(publicKey.toString(), 64, 'Invalid PublicKey');
     }
-
-    /**
-     * Abstract method to derive public key from private key
-     */
-    protected abstract getPublicKey(): Key;
 
     /**
      * Abstract method to signs a data buffer with a key pair.

--- a/src/core/KeyPair.ts
+++ b/src/core/KeyPair.ts
@@ -34,7 +34,7 @@ export abstract class KeyPair {
     /**
      * Abstract method to derive public key from private key
      */
-    public abstract getPublicKey(): Key;
+    protected abstract getPublicKey(): Key;
 
     /**
      * Abstract method to signs a data buffer with a key pair.

--- a/src/core/nis1/Nis1KeyPair.ts
+++ b/src/core/nis1/Nis1KeyPair.ts
@@ -26,7 +26,7 @@ export class Nis1KeyPair extends KeyPair {
      * @param privateKey - Private Key
      */
     constructor(privateKey: Key) {
-        super(privateKey);
+        super(privateKey, Nis1KeyPair.derivePublicKey(privateKey));
     }
 
     /**
@@ -41,11 +41,12 @@ export class Nis1KeyPair extends KeyPair {
     /**
      * Derive public key from private key
      *
+     * @param privateKey - The private key to derive the public key from.
      * @returns Public key
      */
-    protected getPublicKey(): Key {
+    private static derivePublicKey(privateKey: Key): Key {
         const publicKey = new Key(new Uint8Array(Ed25519.crypto_sign_PUBLICKEYBYTES));
-        const reversedPrivateKey = [...this.privateKey.toBytes()].reverse();
+        const reversedPrivateKey = [...privateKey.toBytes()].reverse();
 
         Ed25519.crypto_sign_keypair_hash(publicKey.toBytes(), reversedPrivateKey, keccakHash);
 

--- a/src/core/nis1/Nis1KeyPair.ts
+++ b/src/core/nis1/Nis1KeyPair.ts
@@ -43,7 +43,7 @@ export class Nis1KeyPair extends KeyPair {
      *
      * @returns Public key
      */
-    public getPublicKey(): Key {
+    protected getPublicKey(): Key {
         const publicKey = new Key(new Uint8Array(Ed25519.crypto_sign_PUBLICKEYBYTES));
         const reversedPrivateKey = [...this.privateKey.toBytes()].reverse();
 

--- a/src/core/symbol/SymbolKeyPair.ts
+++ b/src/core/symbol/SymbolKeyPair.ts
@@ -27,7 +27,7 @@ export class SymbolKeyPair extends KeyPair {
      * @param privateKey - Private Key
      */
     constructor(privateKey: Key) {
-        super(privateKey);
+        super(privateKey, SymbolKeyPair.derivePublicKey(privateKey));
     }
 
     /**
@@ -42,10 +42,11 @@ export class SymbolKeyPair extends KeyPair {
     /**
      * Derive public key from private key
      *
+     * @param privateKey - The private key to derive the public key from.
      * @returns Public key
      */
-    protected getPublicKey(): Key {
-        return new Key(nacl.sign.keyPair.fromSeed(this.privateKey.toBytes()).publicKey);
+    private static derivePublicKey(privateKey: Key): Key {
+        return new Key(nacl.sign.keyPair.fromSeed(privateKey.toBytes()).publicKey);
     }
 
     /**

--- a/src/core/symbol/SymbolKeyPair.ts
+++ b/src/core/symbol/SymbolKeyPair.ts
@@ -44,7 +44,7 @@ export class SymbolKeyPair extends KeyPair {
      *
      * @returns Public key
      */
-    public getPublicKey(): Key {
+    protected getPublicKey(): Key {
         return new Key(nacl.sign.keyPair.fromSeed(this.privateKey.toBytes()).publicKey);
     }
 

--- a/test/BasicKeyPairTest.template.ts
+++ b/test/BasicKeyPairTest.template.ts
@@ -30,7 +30,7 @@ export const BasicKeyPairTester = (keyPairClass: KeyPairClass, deterministicPriv
             const keyPair: KeyPair = new keyPairClass(deterministicPrivateKey);
 
             // Assert:
-            expect(expectedPublicKey).to.be.deep.equal(keyPair.getPublicKey());
+            expect(expectedPublicKey).to.be.deep.equal(keyPair.publicKey);
             expect(deterministicPrivateKey).to.be.deep.equal(keyPair.privateKey);
         });
     });


### PR DESCRIPTION
fix: rolledback getPublicKey() public method. There is already a public publicKey field.

I changed from protect to public a method that already has a public publicKey field. This rolls back that mistake.