### PR TITLE
Resolve ts path issue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "@types/ripemd160": "^2.0.0",
                 "@typescript-eslint/eslint-plugin": "^4.28.5",
                 "@typescript-eslint/parser": "^4.28.5",
+                "@zerollup/ts-transform-paths": "^1.7.18",
                 "chai": "^4.3.4",
                 "coveralls": "^3.1.1",
                 "eslint": "^7.32.0",
@@ -43,6 +44,7 @@
                 "ts-mockito": "^2.6.1",
                 "ts-node": "^10.1.0",
                 "tsconfig-paths": "^3.10.1",
+                "ttypescript": "^1.5.12",
                 "typedoc": "^0.21.4",
                 "typescript": "^4.3.5"
             }
@@ -913,6 +915,30 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "node_modules/@zerollup/ts-helpers": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
+            "integrity": "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==",
+            "dev": true,
+            "dependencies": {
+                "resolve": "^1.12.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=3.7.2"
+            }
+        },
+        "node_modules/@zerollup/ts-transform-paths": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.18.tgz",
+            "integrity": "sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==",
+            "dev": true,
+            "dependencies": {
+                "@zerollup/ts-helpers": "^1.7.18"
+            },
+            "peerDependencies": {
+                "typescript": ">=3.7.2"
+            }
         },
         "node_modules/acorn": {
             "version": "7.4.1",
@@ -4248,6 +4274,23 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/ttypescript": {
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+            "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+            "dev": true,
+            "dependencies": {
+                "resolve": ">=1.9.0"
+            },
+            "bin": {
+                "ttsc": "bin/tsc",
+                "ttsserver": "bin/tsserver"
+            },
+            "peerDependencies": {
+                "ts-node": ">=8.0.2",
+                "typescript": ">=3.2.2"
+            }
+        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5329,6 +5372,24 @@
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
+        },
+        "@zerollup/ts-helpers": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
+            "integrity": "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.12.0"
+            }
+        },
+        "@zerollup/ts-transform-paths": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.18.tgz",
+            "integrity": "sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==",
+            "dev": true,
+            "requires": {
+                "@zerollup/ts-helpers": "^1.7.18"
+            }
         },
         "acorn": {
             "version": "7.4.1",
@@ -7996,6 +8057,15 @@
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
+            }
+        },
+        "ttypescript": {
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+            "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+            "dev": true,
+            "requires": {
+                "resolve": ">=1.9.0"
             }
         },
         "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "scripts": {
-        "build": "npx shx rm -rf dist/ && tsc",
+        "build": "npx shx rm -rf dist/ && ttsc",
         "watch": "tsc -b -w",
         "doc": "typedoc --out \"ts-docs/$(npm run version --silent)\" src",
         "test": "env VECTOR_LIMIT=20 mocha -r ts-node/register -r tsconfig-paths/register ./test/**/*.spec.ts ./test/**/*.vector.ts --ui bdd --timeout 120000",
@@ -37,6 +37,7 @@
         "@types/ripemd160": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^4.28.5",
         "@typescript-eslint/parser": "^4.28.5",
+        "@zerollup/ts-transform-paths": "^1.7.18",
         "chai": "^4.3.4",
         "coveralls": "^3.1.1",
         "eslint": "^7.32.0",
@@ -52,6 +53,7 @@
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.1.0",
         "tsconfig-paths": "^3.10.1",
+        "ttypescript": "^1.5.12",
         "typedoc": "^0.21.4",
         "typescript": "^4.3.5"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,11 @@
       "@core": ["src/core"],
       "@utils": ["src/core/utils"],
     },
+    "plugins": [
+      {
+        "transform": "@zerollup/ts-transform-paths"
+      }
+    ]
   },
   "files": [
     "index.ts"


### PR DESCRIPTION
It has a path problem after the build.

- added `ttsc` and `@zerollup/ts-transform-paths` pluges
- export `src`, user can call from SDK library.

thanks, @fboucquez found the issue and provided a solution.
read more https://mitchellsimoens.com/2019/08/07/why-typescript-paths-failed-me/