### PR TITLE
feat: HashUtils and improvements

### DIFF
--- a/src/core/nem/NemAddress.ts
+++ b/src/core/nem/NemAddress.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Address, RawAddress } from '@core';
+import { Address, HashUtils, RawAddress } from '@core';
 import { arrayDeepEqual, Base32, Converter } from '@utils';
-import { keccak256 } from 'js-sha3';
 
 /**
  * The address structure describes an address with its network
@@ -99,9 +98,8 @@ export class NemAddress extends Address {
 
         try {
             const { rawAddress } = NemAddress.createFromString(formatAddress);
-            const hasher = keccak256.create();
-            const hash = hasher.update(rawAddress.addressWithoutChecksum).arrayBuffer();
-            return arrayDeepEqual(new Uint8Array(hash).subarray(0, 4), rawAddress.checksum);
+            const hash = HashUtils.keccak256Hash(rawAddress.addressWithoutChecksum);
+            return arrayDeepEqual(hash.subarray(0, 4), rawAddress.checksum);
         } catch (e) {
             return false;
         }

--- a/src/core/nem/NemNetwork.ts
+++ b/src/core/nem/NemNetwork.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Address, NemAddress, NemNetworkList, NemTransactionFactory, Network, RawAddress } from '@core';
-import { Hash, keccak256 } from 'js-sha3';
+import { Address, HashUtils, NemAddress, NemNetworkList, NemTransactionFactory, Network, RawAddress } from '@core';
 
 export class NemNetwork extends Network {
     /**
@@ -31,11 +30,8 @@ export class NemNetwork extends Network {
     /**
      * Get hasher for address generation based on selected network type
      *
-     * @returns hasher
      */
-    public addressHasher(): Hash {
-        return keccak256;
-    }
+    public addressHasher = HashUtils.keccak256Hash;
 
     /**
      * Creates a transaction factory for Nem transaction.

--- a/src/core/nem/external/index.ts
+++ b/src/core/nem/external/index.ts
@@ -10,7 +10,7 @@ interface INacl {
      * @param privateKey - The private key.
      * @param hashFunc - Hash function use to hash the private key.
      */
-    crypto_sign_keypair(publicKey: Uint8Array, privateKey: number[], hashFunc: (data: Uint8Array) => number[]): void;
+    crypto_sign_keypair(publicKey: Uint8Array, privateKey: number[], hashFunc: (data: Uint8Array) => Uint8Array): void;
     /**
      * Signs a data buffer with a key pair based on the hasher.
      * @param signature - The new signature bytes.

--- a/src/core/symbol/MerkleHashBuilder.ts
+++ b/src/core/symbol/MerkleHashBuilder.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { sha3_256 } from 'js-sha3';
+import { HashUtils } from '@utils';
 
 export class MerkleHashBuilder {
     /**
@@ -67,11 +67,6 @@ export class MerkleHashBuilder {
      * @returns Hashed bytes
      */
     private hash(hashes: Uint8Array[]): Uint8Array {
-        const hasher = sha3_256.create();
-
-        hashes.forEach((hashVal: Uint8Array) => {
-            hasher.update(hashVal);
-        });
-        return new Uint8Array(hasher.arrayBuffer());
+        return HashUtils.sha256Hash(...hashes);
     }
 }

--- a/src/core/symbol/SymbolAddress.ts
+++ b/src/core/symbol/SymbolAddress.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Address, RawAddress } from '@core';
+import { Address, HashUtils, RawAddress } from '@core';
 import { arrayDeepEqual, Base32, Converter } from '@utils';
-import { sha3_256 } from 'js-sha3';
 
 /**
  * The address structure describes an address with its network
@@ -99,9 +98,8 @@ export class SymbolAddress extends Address {
 
         try {
             const { rawAddress } = SymbolAddress.createFromString(formatAddress);
-            const hasher = sha3_256.create();
-            const hash = hasher.update(rawAddress.addressWithoutChecksum).arrayBuffer();
-            return arrayDeepEqual(new Uint8Array(hash).subarray(0, 3), rawAddress.checksum);
+            const hash = HashUtils.sha256Hash(rawAddress.addressWithoutChecksum);
+            return arrayDeepEqual(hash.subarray(0, 3), rawAddress.checksum);
         } catch (e) {
             return false;
         }

--- a/src/core/symbol/SymbolIdGenerator.ts
+++ b/src/core/symbol/SymbolIdGenerator.ts
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Address, Converter, NamespaceConst } from '@core';
+import { Address, Converter, HashUtils, NamespaceConst } from '@core';
 import { toBigIntLE, toBufferLE } from 'bigint-buffer';
 import { GeneratorUtils } from 'catbuffer-typescript';
 import * as Crypto from 'crypto';
-import { sha3_256 } from 'js-sha3';
 
 export class SymbolIdGenerator {
     /**
@@ -28,10 +27,8 @@ export class SymbolIdGenerator {
      * @returns Mosaic id bigint value
      */
     public static generateMosaicId(ownerAddress: Address, nonce: Uint8Array): bigint {
-        const hash = sha3_256.create();
-        hash.update(nonce);
-        hash.update(ownerAddress.getAddressBytes());
-        const result = new Uint32Array(hash.arrayBuffer());
+        const hash = HashUtils.sha256Hash(nonce, ownerAddress.getAddressBytes());
+        const result = Converter.uint8ToUint32(hash);
         return toBigIntLE(Buffer.from(new Uint32Array([result[0], result[1] & 0x7fffffff]).buffer));
     }
 
@@ -52,10 +49,8 @@ export class SymbolIdGenerator {
      * @returns Namespace id bigint value
      */
     public static generateNamespaceId(name: string, parentId = BigInt(0)): bigint {
-        const hash = sha3_256.create();
-        hash.update(toBufferLE(parentId, 8));
-        hash.update(name);
-        const result = new Uint32Array(hash.arrayBuffer());
+        const hash = HashUtils.sha256Hash(toBufferLE(parentId, 8), name);
+        const result = Converter.uint8ToUint32(hash);
         // right zero-filling required to keep unsigned number representation
         return toBigIntLE(Buffer.from(new Uint32Array([result[0], (result[1] | 0x80000000) >>> 0]).buffer));
     }

--- a/src/core/symbol/SymbolNetwork.ts
+++ b/src/core/symbol/SymbolNetwork.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Network, RawAddress, SymbolAddress, SymbolNetworkList, SymbolTransactionFactory } from '@core';
-import { Hash, sha3_256 } from 'js-sha3';
+import { HashUtils, Network, RawAddress, SymbolAddress, SymbolNetworkList, SymbolTransactionFactory } from '@core';
 
 export class SymbolNetwork extends Network {
     /**
@@ -39,11 +38,8 @@ export class SymbolNetwork extends Network {
     /**
      * Get hasher for address generation based on selected network type
      *
-     * @returns SHA3 hasher
      */
-    public addressHasher(): Hash {
-        return sha3_256;
-    }
+    public addressHasher = HashUtils.sha256Hash;
 
     /**
      * List all networks

--- a/src/core/symbol/SymbolTransactionUtils.ts
+++ b/src/core/symbol/SymbolTransactionUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { KeyPair, MerkleHashBuilder } from '@core';
+import { HashUtils, KeyPair, MerkleHashBuilder } from '@core';
 import { Converter } from '@utils';
 import * as allBuilders from 'catbuffer-typescript';
 import {
@@ -125,7 +125,7 @@ export class SymbolTransactionUtils {
         const signature = transactionPayload.slice(8, 8 + 64);
         const publicKey = transactionPayload.slice(8 + 64, 8 + 64 + 32);
         // layout: `signature_R || signerPublicKey || generationHash || EntityDataBuffer`
-        return Converter.hash(signature, publicKey, generationHash, transactionBody);
+        return HashUtils.sha256Hash(signature, publicKey, generationHash, transactionBody);
     }
 
     /**
@@ -234,7 +234,7 @@ export class SymbolTransactionUtils {
         const builder = new MerkleHashBuilder();
         transactions.forEach((transaction) => {
             const padding = new Uint8Array(GeneratorUtils.getPaddingSize(transaction.length, 8));
-            builder.update(Converter.hash(Converter.concat(transaction, padding)));
+            builder.update(HashUtils.sha256Hash(Converter.concat(transaction, padding)));
         });
         return builder.final();
     }

--- a/src/core/utils/Converter.ts
+++ b/src/core/utils/Converter.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { Nibble_To_Char_Map } from '@core';
-import { sha3_256 } from 'js-sha3';
 import { decode } from 'utf8';
 import { tryParseByte } from './Utilities';
 
@@ -301,20 +300,5 @@ export class Converter {
             length += array.length;
         }
         return result;
-    }
-
-    /**
-     * It hashes the list of Uint8Array into a Uint8Array.
-     *
-     * This method abstracts out the sha3 implementation, if for some reason the hash needs to be changed, it's centralized in one place.
-     *
-     * @param hashes - the list of Uint8Array to hash.
-     */
-    public static hash(...hashes: Uint8Array[]): Uint8Array {
-        const hasher = sha3_256.create();
-        hashes.forEach((hashVal: Uint8Array) => {
-            hasher.update(hashVal);
-        });
-        return new Uint8Array(hasher.arrayBuffer());
     }
 }

--- a/src/core/utils/HashUtils.ts
+++ b/src/core/utils/HashUtils.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021 SYMBOL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Hash, keccak256, keccak512, sha3_256 } from 'js-sha3';
+import * as ripemd160 from 'ripemd160';
+
+/**
+ * The type of data HashUtils can hash.
+ */
+type Message = Uint8Array | string;
+
+/**
+ * Interface of a hasher that keeps the state of the hashed data.
+ */
+export interface Hasher {
+    /**
+     * @param data - the data to hash
+     * @returns this hasher
+     */
+    update(data: Message): Hasher;
+
+    /**
+     * returns the hash of the provided data.
+     * @returns the hash of the data
+     */
+    digest(): Uint8Array;
+
+    /**
+     * It resets the hashed data to empty
+     * @returns this hasher
+     */
+    reset(): Hasher;
+}
+
+/**
+ * A utility class to hash data easily. It handles keccak256, keccak512, sha3_256 and ripemd160 implementations.
+ *
+ * For each implementation, this helper provides a Hasher factory and a one-line hash function.
+ *
+ * This class abstracts out the the implementation, if for some reason the hashes need to be changed, it's centralized in one place.
+ *
+ * Clients wouldn't need to import any hash implementation like 'ripemd160' or 'js-sha3', just use this helper utils.
+ */
+export class HashUtils {
+    /**
+     * It keccak512 hashes the list of Uint8Array into a Uint8Array.
+     *
+     * @param data - the list of Uint8Array to hash.
+     * @returns the keccak512 hash of the data.
+     */
+    public static keccak512Hash = (...data: Message[]): Uint8Array => {
+        return HashUtils.hash(HashUtils.keccak512Hasher(), ...data);
+    };
+
+    /**
+     * It creates a keccak512 hasher.
+     *
+     * @returns a keccak512 hasher
+     */
+    public static keccak512Hasher = (): Hasher => {
+        return HashUtils.createHasher(keccak512);
+    };
+
+    /**
+     * It keccak256 hashes the list of Uint8Array into a Uint8Array.
+     *
+     * @param data - the list of Uint8Array to hash.
+     * @returns the keccak256 hash of the data.
+     */
+    public static keccak256Hash = (...data: Message[]): Uint8Array => {
+        return HashUtils.hash(HashUtils.keccak256Hasher(), ...data);
+    };
+
+    /**
+     * It creates a keccak256 hasher.
+     *
+     * @returns a keccak256 hasher
+     */
+    public static keccak256Hasher = (): Hasher => {
+        return HashUtils.createHasher(keccak256);
+    };
+
+    /**
+     * It sha256 hashes the list of Uint8Array into a Uint8Array.
+     *
+     * @param data - the list of Uint8Array to hash.
+     * @returns the sha256 hash of the data.
+     */
+    public static sha256Hash = (...data: Message[]): Uint8Array => {
+        return HashUtils.hash(HashUtils.sha256Hasher(), ...data);
+    };
+    /**
+     * It creates a sha3_256 hasher.
+     */
+    public static sha256Hasher = (): Hasher => {
+        return HashUtils.createHasher(sha3_256);
+    };
+
+    /**
+     * It hashes the given items into a Uint8Array using the provided hasher.
+     * @param hasher - the hasher algorithm.
+     * @param data - the item to hash
+     */
+    private static hash(hasher: Hasher, ...data: Message[]): Uint8Array {
+        hasher.reset();
+        data.forEach((hashVal: Uint8Array) => {
+            hasher.update(hashVal);
+        });
+        return hasher.digest();
+    }
+
+    /**
+     * It ripemd160 hashes the list of Uint8Array into a Uint8Array.
+     *
+     * @param data - the list of Uint8Array to hash.
+     * @returns the ripemd160 hash of the data.
+     */
+    public static ripemd160Hash = (...data: Uint8Array[]): Uint8Array => {
+        return HashUtils.hash(HashUtils.ripemd160Hasher(), ...data);
+    };
+
+    /**
+     * It creates a ripemd160 hasher.
+     *
+     * @returns a ripemd160 hasher
+     */
+    public static ripemd160Hasher = (): Hasher => {
+        let hasherImpl = new ripemd160();
+        const hasher: Hasher = {
+            update: (data: Message): Hasher => {
+                hasherImpl.update(Buffer.from(data));
+                return hasher;
+            },
+            digest: () => hasherImpl.digest(),
+            reset: (): Hasher => {
+                hasherImpl = new ripemd160();
+                return hasher;
+            },
+        };
+        return hasher;
+    };
+
+    /**
+     * It creates a Hasher from the provided js-sha3
+     * @param hash - the js-sha3 hash
+     * @returns the Hasher wrapper.
+     */
+    private static createHasher(hash: Hash): Hasher {
+        let hasherImpl = hash.create();
+        const hasher: Hasher = {
+            update: (data: Message): Hasher => {
+                hasherImpl.update(data);
+                return hasher;
+            },
+            digest: () => Uint8Array.from(hasherImpl.digest()),
+            reset: (): Hasher => {
+                hasherImpl = hash.create();
+                return hasher;
+            },
+        };
+        return hasher;
+    }
+}

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './Base32';
 export * from './Converter';
+export * from './HashUtils';
 export * from './Utilities';

--- a/test/BasicVectorTest.template.ts
+++ b/test/BasicVectorTest.template.ts
@@ -85,7 +85,8 @@ export const AddressMosaicIdTester = <T extends Network>(
                     expect(item[addressKeyName]).to.be.equal(address.encoded);
                     if (testMosaicId) {
                         const mosaicId = SymbolIdGenerator.generateMosaicId(address, toBufferLE(BigInt(item['mosaicNonce']), 4));
-                        expect(item[mosaicKeyName]).to.be.equal(mosaicId.toString(16).toLocaleUpperCase().padStart(16, '0'));
+                        const value = mosaicId.toString(16).toLocaleUpperCase().padStart(16, '0');
+                        expect(value).to.be.equal(item[mosaicKeyName]);
                     }
                 });
             },

--- a/test/core/nem/NemNetwork.spec.ts
+++ b/test/core/nem/NemNetwork.spec.ts
@@ -46,11 +46,10 @@ describe('Nem Network', () => {
             // Arrange:
             const network = new NemNetwork('testnet', 0x98);
             const randomHash = crypto.randomBytes(32);
-            const expected = keccak256.arrayBuffer(randomHash);
+            const expected = new Uint8Array(keccak256.digest(randomHash));
 
             // Act:
-            const hasher = network.addressHasher();
-            const hash = hasher.arrayBuffer(randomHash);
+            const hash = network.addressHasher(randomHash);
 
             // Assert:
             expect(hash).to.be.deep.equal(expected);

--- a/test/core/symbol/SymbolNetwork.spec.ts
+++ b/test/core/symbol/SymbolNetwork.spec.ts
@@ -50,11 +50,10 @@ describe('Symbol Network', () => {
         it('can create correct hasher', () => {
             // Arrange:
             const network = new SymbolNetwork('mainnet', 0x68, mainnetGenerationHash);
-            const expected = sha3_256.arrayBuffer(network.generationHash);
+            const expected = new Uint8Array(sha3_256.digest(network.generationHash));
 
             // Act:
-            const hasher = network.addressHasher();
-            const hash = hasher.arrayBuffer(network.generationHash);
+            const hash = network.addressHasher(network.generationHash);
 
             // Assert:
             expect(hash).to.be.deep.equal(expected);

--- a/test/utils/HashUtils.spec.ts
+++ b/test/utils/HashUtils.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 SYMBOL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Converter, Hasher, HashUtils } from '@core';
+import { expect } from 'chai';
+
+describe('HashUtils', () => {
+    const uint8Array = Uint8Array.of(1, 2, 3, 4);
+    const buffer = Buffer.from(uint8Array);
+    const string = buffer.toString();
+
+    function assertHasher(hasher: Hasher, expectedHash: string) {
+        expect(Converter.uint8ToHex(Uint8Array.from(hasher.reset().update(uint8Array).digest()))).eq(expectedHash);
+        expect(Converter.uint8ToHex(Uint8Array.from(hasher.reset().update(buffer).digest()))).eq(expectedHash);
+        expect(Converter.uint8ToHex(Uint8Array.from(hasher.reset().update(string).digest()))).eq(expectedHash);
+    }
+
+    function assertHash(hash: (data: Uint8Array | string) => Uint8Array, expectedHash: string) {
+        expect(Converter.uint8ToHex(Uint8Array.from(hash(uint8Array)))).eq(expectedHash);
+        expect(Converter.uint8ToHex(Uint8Array.from(hash(buffer)))).eq(expectedHash);
+        expect(Converter.uint8ToHex(Uint8Array.from(hash(string)))).eq(expectedHash);
+    }
+
+    it('sha256 hasher', () => {
+        assertHasher(HashUtils.sha256Hasher(), '966DBDCBD0E0348FAA1CCBCE5A62B8E73B0D08955D666DB82243B303D9BD9502');
+    });
+
+    it('sha256 hash', () => {
+        assertHash(HashUtils.sha256Hash, '966DBDCBD0E0348FAA1CCBCE5A62B8E73B0D08955D666DB82243B303D9BD9502');
+    });
+
+    it('keccak512 hasher', () => {
+        assertHasher(
+            HashUtils.keccak512Hasher(),
+            'B6EB21E44EA147D237E8E708427DA11EDED32C0B89371B75B35BED1076CD8E2D2F8D7775339AD1D26BFB7DA5658F20C3714A33F62F81C2935180179EC7BB1B2D',
+        );
+    });
+
+    it('keccak512 hash', () => {
+        assertHash(
+            HashUtils.keccak512Hash,
+            'B6EB21E44EA147D237E8E708427DA11EDED32C0B89371B75B35BED1076CD8E2D2F8D7775339AD1D26BFB7DA5658F20C3714A33F62F81C2935180179EC7BB1B2D',
+        );
+    });
+
+    it('keccak256 hasher', () => {
+        assertHasher(HashUtils.keccak256Hasher(), 'A6885B3731702DA62E8E4A8F584AC46A7F6822F4E2BA50FBA902F67B1588D23B');
+    });
+
+    it('keccak256 hash', () => {
+        assertHash(HashUtils.keccak256Hash, 'A6885B3731702DA62E8E4A8F584AC46A7F6822F4E2BA50FBA902F67B1588D23B');
+    });
+
+    it('keccak256 hasher', () => {
+        assertHasher(HashUtils.ripemd160Hasher(), '179BB366E5E224B8BF4CE302CEFC5744961839C5');
+    });
+
+    it('ripemd160 hash', () => {
+        assertHash(HashUtils.ripemd160Hash, '179BB366E5E224B8BF4CE302CEFC5744961839C5');
+    });
+});

--- a/test/vector-tests/AllTests.vector.ts
+++ b/test/vector-tests/AllTests.vector.ts
@@ -5,7 +5,7 @@ import {
     DeriveVectorTester,
     KeyPairVectorTester,
     SignAndVerifyTester,
-} from 'test/BasicVectorTest.template';
+} from '../BasicVectorTest.template';
 import path = require('path');
 
 describe('Nem', () => {


### PR DESCRIPTION
While I was trying to hash different serialized nem transactions, I found out there wasn't a nice hash utility class that I could use to hash data. I needed to include a specific library in order to do the operation. 

I've done a smallish refactoring around how hashes are performed in the SDK. Basically added a HashUtils that centralizes and hides the different implementations. If for some reason we need to change the implementation of one of them, we would just change the HashUtils and not the different classes. 

Any SDK user (internal class or an app) can just use HashUtils to perform hashes. `HashUtils` is like the `Converter` for hashes